### PR TITLE
Update 03-using-other-network-layers.md

### DIFF
--- a/docs/03-using-other-network-layers.md
+++ b/docs/03-using-other-network-layers.md
@@ -20,8 +20,8 @@ pipeline有一个使用OkHttp替换掉了Android默认的网络请求的补充�
 ```groovy
 dependencies {
   // your project's other dependencies
-  compile: "com.facebook.fresco:drawee:0.1.0+"
-  compile: "com.facebook.fresco:imagepipeline-okhttp:0.1.0+"
+  compile: 'com.facebook.fresco:drawee:0.1.0+'
+  compile: 'com.facebook.fresco:imagepipeline-okhttp:0.1.0+'
 }
 ```
 

--- a/docs/03-using-other-network-layers.md
+++ b/docs/03-using-other-network-layers.md
@@ -20,8 +20,8 @@ pipeline有一个使用OkHttp替换掉了Android默认的网络请求的补充�
 ```groovy
 dependencies {
   // your project's other dependencies
-  compile: 'com.facebook.fresco:drawee:0.1.0+'
-  compile: 'com.facebook.fresco:imagepipeline-okhttp:0.1.0+'
+  compile 'com.facebook.fresco:drawee:0.1.0+'
+  compile 'com.facebook.fresco:imagepipeline-okhttp:0.1.0+'
 }
 ```
 


### PR DESCRIPTION
gradle中使用单引号  双引号会导致编译通不过
